### PR TITLE
Custom User Statuses

### DIFF
--- a/backend/app/controllers/api/v1/statuses_controller.rb
+++ b/backend/app/controllers/api/v1/statuses_controller.rb
@@ -1,0 +1,71 @@
+class Api::V1::StatusesController < Api::V1::BaseController
+  before_action :set_status, only: [:show, :update, :destroy]
+
+  def index
+    @statuses = current_user.statuses.order(:name)
+    render json: serialize_statuses_light(@statuses)
+  end
+
+  def show
+    render json: serialize_status_light(@status)
+  end
+
+  def create
+    @status = current_user.statuses.build(status_params)
+    if @status.save
+      render json: serialize_status_light(@status), status: :created
+    else
+      render json: @status.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @status.update(status_params)
+      render json: serialize_status_light(@status)
+    else
+      render json: @status.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @status.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_status
+    @status = current_user.statuses.find(params[:id])
+  end
+
+  def status_params
+    params.require(:status).permit(:name)
+  end
+
+  # Lightweight serialization for statuses - avoids loading all transactions
+  def serialize_statuses_light(statuses)
+    {
+      data: statuses.map do |status|
+        {
+          id: status.id.to_s,
+          type: "status",
+          attributes: {
+            name: status.name
+          }
+        }
+      end
+    }
+  end
+
+  def serialize_status_light(status)
+    {
+      data: {
+        id: status.id.to_s,
+        type: "status",
+        attributes: {
+          name: status.name
+        }
+      }
+    }
+  end
+end

--- a/backend/app/controllers/api/v1/transactions_controller.rb
+++ b/backend/app/controllers/api/v1/transactions_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     cached_result = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
       # Get basic transaction data with minimal includes
       @transactions = current_user.transactions
-                                .includes(:category)
+                                .includes(:category, :status)
                                 .order(date: :desc)
                                 .page(params[:page] || 1)
                                 .per(params[:per_page] || 20)
@@ -165,17 +165,28 @@ class Api::V1::TransactionsController < Api::V1::BaseController
         notes: transaction.notes,
         formatted_datetime: transaction.date.iso8601,
         category_name: transaction.category&.name,
+        status_name: transaction.status&.name,
         created_at: transaction.created_at,
         updated_at: transaction.updated_at
       },
-      relationships: transaction.category ? {
-        category: {
-          data: {
-            id: transaction.category.id.to_s,
-            type: 'category'
+      relationships: {}.tap do |rels|
+        if transaction.category
+          rels[:category] = {
+            data: {
+              id: transaction.category.id.to_s,
+              type: 'category'
+            }
           }
-        }
-      } : {}
+        end
+        if transaction.status
+          rels[:status] = {
+            data: {
+              id: transaction.status.id.to_s,
+              type: 'status'
+            }
+          }
+        end
+      end
     }
   end
 
@@ -220,6 +231,6 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   end
 
   def transaction_params
-    params.require(:transaction).permit(:date, :amount, :description, :category_id, :notes)
+    params.require(:transaction).permit(:date, :amount, :description, :category_id, :status_id, :notes)
   end
 end

--- a/backend/app/controllers/api/v1/transactions_controller.rb
+++ b/backend/app/controllers/api/v1/transactions_controller.rb
@@ -4,35 +4,24 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   before_action :set_transaction, only: [:show, :update, :destroy, :categorize]
 
   def index
-    # Create cache key based on current filters and user's transaction updates
-    cache_key = "user_#{current_user.id}_transactions_#{cache_key_suffix}"
-    
-    # Cache for 1 minute for frequently accessed data
-    cached_result = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
-      # Get basic transaction data with minimal includes
-      @transactions = current_user.transactions
-                                .includes(:category, :user_status)
-                                .order(date: :desc)
-                                .page(params[:page] || 1)
-                                .per(params[:per_page] || 20)
-
-      # Apply filters
-      apply_filters
-
-      # Serialize data
-      {
-        data: @transactions.map { |t| serialize_transaction_light(t) },
-        meta: {
-          total_pages: @transactions.total_pages,
-          total_count: @transactions.total_count,
-          current_page: @transactions.current_page
-        }
-      }
+    # Bypass cache if _bust parameter is present
+    if params[:_bust].present?
+      Rails.logger.debug "Cache busting requested for user #{current_user.id}"
+      result = fetch_transactions_data
+      render json: result
+    else
+      # Create cache key based on current filters and user's transaction updates
+      cache_key = "user_#{current_user.id}_transactions_#{cache_key_suffix}"
+      
+      # Cache for 1 minute for frequently accessed data
+      cached_result = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
+        fetch_transactions_data
+      end
+      
+      # Set cache headers
+      expires_in 30.seconds, public: false
+      render json: cached_result
     end
-
-    # Set cache headers
-    expires_in 30.seconds, public: false
-    render json: cached_result
   end
 
   def category_totals
@@ -140,9 +129,33 @@ class Api::V1::TransactionsController < Api::V1::BaseController
 
   private
 
+  def fetch_transactions_data
+    # Get basic transaction data with minimal includes
+    @transactions = current_user.transactions
+                              .includes(:category, :user_status)
+                              .order(date: :desc)
+                              .page(params[:page] || 1)
+                              .per(params[:per_page] || 20)
+
+    # Apply filters
+    apply_filters
+
+    # Serialize data
+    {
+      data: @transactions.map { |t| serialize_transaction_light(t) },
+      meta: {
+        total_pages: @transactions.total_pages,
+        total_count: @transactions.total_count,
+        current_page: @transactions.current_page
+      }
+    }
+  end
+
   def invalidate_transaction_cache
+    # Delete all cache patterns for this user
     Rails.cache.delete_matched("user_#{current_user.id}_transactions_*")
     Rails.cache.delete_matched("user_#{current_user.id}_category_totals_*")
+    
     Rails.logger.debug "Invalidated transaction and category totals cache for user #{current_user.id}"
   end
 

--- a/backend/app/controllers/api/v1/transactions_controller.rb
+++ b/backend/app/controllers/api/v1/transactions_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
     cached_result = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
       # Get basic transaction data with minimal includes
       @transactions = current_user.transactions
-                                .includes(:category, :status)
+                                .includes(:category, :user_status)
                                 .order(date: :desc)
                                 .page(params[:page] || 1)
                                 .per(params[:per_page] || 20)
@@ -120,6 +120,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
       update_params = {}
       update_params[:status] = params[:status] if params[:status].present?
       update_params[:category_id] = params[:category_id] if params[:category_id].present?
+      update_params[:status_id] = params[:status_id] if params[:status_id].present?
       
       if transaction.update(update_params)
         updated_count += 1
@@ -165,7 +166,7 @@ class Api::V1::TransactionsController < Api::V1::BaseController
         notes: transaction.notes,
         formatted_datetime: transaction.date.iso8601,
         category_name: transaction.category&.name,
-        status_name: transaction.status&.name,
+        status_name: transaction.user_status&.name,
         created_at: transaction.created_at,
         updated_at: transaction.updated_at
       },
@@ -178,10 +179,10 @@ class Api::V1::TransactionsController < Api::V1::BaseController
             }
           }
         end
-        if transaction.status
+        if transaction.user_status
           rels[:status] = {
             data: {
-              id: transaction.status.id.to_s,
+              id: transaction.user_status.id.to_s,
               type: 'status'
             }
           }
@@ -191,8 +192,15 @@ class Api::V1::TransactionsController < Api::V1::BaseController
   end
 
   def apply_filters
+    # Log the filter parameters for debugging
+    Rails.logger.info "Transaction filter params: status=#{params[:status]}, status_id=#{params[:status_id]}"
+    
     if params[:status].present?
       @transactions = @transactions.where(status: params[:status])
+    end
+
+    if params[:status_id].present?
+      @transactions = @transactions.where(status_id: params[:status_id])
     end
 
     # Handle special anomaly filtering

--- a/backend/app/jobs/anomaly_detection_job.rb
+++ b/backend/app/jobs/anomaly_detection_job.rb
@@ -20,7 +20,7 @@ class AnomalyDetectionJob < ApplicationJob
     end
 
     # Update status based on anomalies and validation rules
-    transaction.send(:set_status)
+    transaction.send(:set_final_status)
     
     # Skip anomaly detection callback when saving to prevent infinite loop
     transaction.skip_anomaly_detection = true
@@ -43,7 +43,7 @@ class AnomalyDetectionJob < ApplicationJob
 
     # Update statuses and save
     transactions.each do |transaction|
-      transaction.send(:set_status)
+      transaction.send(:set_final_status)
       transaction.skip_anomaly_detection = true
       transaction.save!(validate: false)
     end

--- a/backend/app/models/status.rb
+++ b/backend/app/models/status.rb
@@ -1,7 +1,6 @@
 class Status < ApplicationRecord
   belongs_to :user
-  has_many :transactions
-  has_many :rules
+  has_many :transactions, foreign_key: 'status_id'
 
   validates :name, presence: true
   validates :name, uniqueness: { scope: :user_id }

--- a/backend/app/models/status.rb
+++ b/backend/app/models/status.rb
@@ -1,0 +1,8 @@
+class Status < ApplicationRecord
+  belongs_to :user
+  has_many :transactions
+  has_many :rules
+
+  validates :name, presence: true
+  validates :name, uniqueness: { scope: :user_id }
+end

--- a/backend/app/models/transaction.rb
+++ b/backend/app/models/transaction.rb
@@ -1,5 +1,6 @@
 class Transaction < ApplicationRecord
   belongs_to :category, optional: true
+  belongs_to :status, optional: true
   belongs_to :user
 
   validates :date, presence: true

--- a/backend/app/models/transaction.rb
+++ b/backend/app/models/transaction.rb
@@ -1,6 +1,6 @@
 class Transaction < ApplicationRecord
   belongs_to :category, optional: true
-  belongs_to :status, optional: true
+  belongs_to :user_status, class_name: 'Status', foreign_key: 'status_id', optional: true
   belongs_to :user
 
   validates :date, presence: true

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
 
   has_many :categories, dependent: :destroy
+  has_many :statuses, dependent: :destroy
   has_many :transactions, dependent: :destroy
   has_many :rules, dependent: :destroy
   has_many :bulk_imports, dependent: :destroy

--- a/backend/app/services/rule_application_service.rb
+++ b/backend/app/services/rule_application_service.rb
@@ -55,6 +55,16 @@ class RuleApplicationService
   
   def self.apply_status_rule(transaction, rule)
     # Status can be overridden by rules (last matching rule wins for status)
-    transaction.status = rule.action_value
+    if rule.action_value.present?
+      # Check if action_value is a status ID (numeric) or a legacy string status
+      if rule.action_value.match?(/^\d+$/)
+        # It's a status ID - set the foreign key and mark status as custom
+        transaction.status_id = rule.action_value.to_i
+        transaction.status = 'custom' # Non-default status to prevent override
+      else
+        # It's a legacy string status - set the status field
+        transaction.status = rule.action_value
+      end
+    end
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       end
       
       resources :categories
+      resources :statuses
       resources :rules
       
       # Bulk import routes

--- a/backend/db/migrate/20250827213328_create_statuses.rb
+++ b/backend/db/migrate/20250827213328_create_statuses.rb
@@ -1,0 +1,12 @@
+class CreateStatuses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :statuses do |t|
+      t.string :name, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    
+    add_index :statuses, [:user_id, :name], unique: true
+  end
+end

--- a/backend/db/migrate/20250827213343_add_status_to_transactions.rb
+++ b/backend/db/migrate/20250827213343_add_status_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddStatusToTransactions < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :transactions, :status, null: true, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_22_184523) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_27_213343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -65,6 +65,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_22_184523) do
     t.index ["user_id"], name: "index_rules_on_user_id"
   end
 
+  create_table "statuses", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_statuses_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_statuses_on_user_id"
+  end
+
   create_table "transactions", force: :cascade do |t|
     t.datetime "date"
     t.decimal "amount"
@@ -75,8 +84,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_22_184523) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "notes"
+    t.bigint "status_id"
     t.index ["category_id"], name: "index_transactions_on_category_id"
     t.index ["description"], name: "index_transactions_on_description"
+    t.index ["status_id"], name: "index_transactions_on_status_id"
     t.index ["user_id", "category_id"], name: "index_transactions_on_user_id_and_category_id"
     t.index ["user_id", "created_at"], name: "index_transactions_for_historical_analysis"
     t.index ["user_id", "date", "amount", "description"], name: "index_transactions_for_duplicate_detection"
@@ -103,6 +114,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_22_184523) do
   add_foreign_key "categories", "users"
   add_foreign_key "rules", "categories"
   add_foreign_key "rules", "users"
+  add_foreign_key "statuses", "users"
   add_foreign_key "transactions", "categories"
+  add_foreign_key "transactions", "statuses"
   add_foreign_key "transactions", "users"
 end

--- a/frontend/src/components/BulkStatusSelect.js
+++ b/frontend/src/components/BulkStatusSelect.js
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { getStatuses, createStatus } from '../services/statuses';
+
+const BulkStatusSelect = ({ onSelect, onCancel, disabled }) => {
+  const [statuses, setStatuses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showNewStatus, setShowNewStatus] = useState(false);
+  const [newStatusName, setNewStatusName] = useState('');
+  const [error, setError] = useState(null);
+  const [selectedStatusId, setSelectedStatusId] = useState('');
+
+  useEffect(() => {
+    fetchStatuses();
+  }, []);
+
+  const fetchStatuses = async () => {
+    try {
+      setLoading(true);
+      const response = await getStatuses();
+      const statusesData = response?.data || [];
+      console.log('Statuses loaded:', statusesData);
+      setStatuses(statusesData);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+      setStatuses([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateSubmit = async () => {
+    if (!newStatusName.trim()) return;
+
+    try {
+      setLoading(true);
+      const response = await createStatus({ name: newStatusName.trim() });
+      if (response?.data) {
+        const newStatus = response.data;
+        setStatuses(prev => [...prev, newStatus]);
+        setSelectedStatusId(newStatus.id);
+        setNewStatusName('');
+        setShowNewStatus(false);
+        setError(null);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (selectedStatusId) {
+      onSelect(selectedStatusId);
+    }
+  };
+
+  if (showNewStatus) {
+    return (
+      <div>
+        <div className="mb-3">
+          <label className="form-label">New Status Name</label>
+          <div className="input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Enter status name"
+              value={newStatusName}
+              onChange={(e) => setNewStatusName(e.target.value)}
+              disabled={loading || disabled}
+              onKeyPress={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleCreateSubmit();
+                }
+              }}
+            />
+            <button 
+              type="button"
+              className="btn btn-primary"
+              onClick={handleCreateSubmit}
+              disabled={loading || disabled || !newStatusName.trim()}
+            >
+              {loading ? (
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+              ) : 'Create'}
+            </button>
+          </div>
+        </div>
+        <div className="d-flex justify-content-end">
+          <button 
+            type="button" 
+            className="btn btn-secondary"
+            onClick={() => setShowNewStatus(false)}
+            disabled={loading || disabled}
+          >
+            Back to Selection
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3">
+        <label className="form-label">Select Status</label>
+        <div className="input-group">
+          <select
+            className="form-select"
+            value={selectedStatusId}
+            onChange={(e) => setSelectedStatusId(e.target.value)}
+            disabled={loading || disabled}
+          >
+            <option value="">Select a status</option>
+            {statuses.map(status => (
+              <option 
+                key={status.id} 
+                value={status.id}
+              >
+                {status.attributes?.name || 'Unnamed Status'}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={() => setShowNewStatus(true)}
+            disabled={loading || disabled}
+          >
+            <i className="fas fa-plus"></i> New
+          </button>
+        </div>
+      </div>
+      {error && (
+        <div className="alert alert-danger mb-3" role="alert">
+          {error}
+        </div>
+      )}
+      <div className="d-flex justify-content-end gap-2">
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={onCancel}
+          disabled={disabled}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleConfirm}
+          disabled={!selectedStatusId || loading || disabled}
+        >
+          Apply Status
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BulkStatusSelect;

--- a/frontend/src/components/RuleForm.js
+++ b/frontend/src/components/RuleForm.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { getCategories } from '../services/categories';
+import { getStatuses } from '../services/statuses';
 import CategorySelect from './CategorySelect';
+import StatusSelect from './StatusSelect';
 
 const RuleForm = ({ rule, onSubmit, onCancel }) => {
   const [formData, setFormData] = useState({
@@ -9,18 +11,24 @@ const RuleForm = ({ rule, onSubmit, onCancel }) => {
     action_type: 'set_category',
     action_value: '',
     category_id: '',
+    status_id: '',
     order: ''
   });
   const [categories, setCategories] = useState([]);
+  const [statuses, setStatuses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Fetch categories on component mount
+  // Fetch categories and statuses on component mount
   useEffect(() => {
-    const fetchCategories = async () => {
+    const fetchData = async () => {
       try {
-        const response = await getCategories();
-        setCategories(response?.data || []);
+        const [categoriesResponse, statusesResponse] = await Promise.all([
+          getCategories(),
+          getStatuses()
+        ]);
+        setCategories(categoriesResponse?.data || []);
+        setStatuses(statusesResponse?.data || []);
       } catch (err) {
         setError(err.message);
       } finally {
@@ -28,7 +36,7 @@ const RuleForm = ({ rule, onSubmit, onCancel }) => {
       }
     };
 
-    fetchCategories();
+    fetchData();
   }, []);
 
   // Set initial form data if editing a rule
@@ -40,6 +48,7 @@ const RuleForm = ({ rule, onSubmit, onCancel }) => {
         action_type: rule.attributes.action_type,
         action_value: rule.attributes.action_value,
         category_id: rule.relationships?.category?.data?.id || '',
+        status_id: rule.relationships?.status?.data?.id || '',
         order: rule.attributes.order || ''
       });
     }
@@ -50,6 +59,14 @@ const RuleForm = ({ rule, onSubmit, onCancel }) => {
       ...prev,
       category_id: categoryId,
       action_value: categoryId
+    }));
+  };
+
+  const handleStatusChange = (statusId) => {
+    setFormData(prev => ({
+      ...prev,
+      status_id: statusId,
+      action_value: statusId
     }));
   };
 
@@ -134,16 +151,15 @@ const RuleForm = ({ rule, onSubmit, onCancel }) => {
             }}
           />
         ) : (
-          <select
-            className="form-select"
-            value={formData.action_value}
-            onChange={(e) => setFormData(prev => ({ ...prev, action_value: e.target.value }))}
-          >
-            <option value="">Select a status...</option>
-            <option value="valid">Valid</option>
-            <option value="invalid">Invalid</option>
-            <option value="high_value">High Value</option>
-          </select>
+          <StatusSelect
+            value={formData.status_id}
+            onChange={handleStatusChange}
+            statuses={statuses}
+            onStatusCreated={(newStatus) => {
+              setStatuses(prev => [...prev, newStatus]);
+              handleStatusChange(newStatus.id);
+            }}
+          />
         )}
       </div>
 

--- a/frontend/src/components/StatusSelect.js
+++ b/frontend/src/components/StatusSelect.js
@@ -1,0 +1,127 @@
+import React, { useState, memo, useCallback } from 'react';
+import { createStatus } from '../services/statuses';
+
+const StatusSelect = memo(({ value, onChange, onError, statuses = [], onStatusCreated }) => {
+  const [loading, setLoading] = useState(false);
+  const [showNewStatus, setShowNewStatus] = useState(false);
+  const [newStatusName, setNewStatusName] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleCreateStatus = useCallback(async (e) => {
+    e.preventDefault();
+    if (!newStatusName.trim()) return;
+
+    try {
+      setLoading(true);
+      const response = await createStatus({ name: newStatusName.trim() });
+      if (response?.data) {
+        onStatusCreated?.(response.data);
+        onChange(response.data.id);
+        setNewStatusName('');
+        setShowNewStatus(false);
+        setError(null);
+      }
+    } catch (err) {
+      setError(err.message);
+      onError?.(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [newStatusName, onStatusCreated, onChange, onError]);
+
+  const handleCreateSubmit = useCallback(async () => {
+    if (!newStatusName.trim()) return;
+
+    try {
+      setLoading(true);
+      const response = await createStatus({ name: newStatusName.trim() });
+      if (response?.data) {
+        const newStatus = response.data;
+        onStatusCreated?.(newStatus);
+        onChange(newStatus.id);
+        setNewStatusName('');
+        setShowNewStatus(false);
+        setError(null);
+      }
+    } catch (err) {
+      setError(err.message);
+      onError?.(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [newStatusName, onStatusCreated, onChange, onError]);
+
+  if (showNewStatus) {
+    return (
+      <div className="new-status-form">
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="Enter status name"
+            value={newStatusName}
+            onChange={(e) => setNewStatusName(e.target.value)}
+            disabled={loading}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleCreateSubmit();
+              }
+            }}
+          />
+          <button 
+            type="button"
+            className="btn btn-primary"
+            onClick={handleCreateSubmit}
+            disabled={loading || !newStatusName.trim()}
+          >
+            {loading ? (
+              <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+            ) : 'Create'}
+          </button>
+          <button 
+            type="button" 
+            className="btn btn-secondary"
+            onClick={() => setShowNewStatus(false)}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="input-group">
+      <select
+        className="form-select"
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={loading}
+      >
+        <option value="">Select a status</option>
+        {statuses.map(status => (
+          <option 
+            key={status.id} 
+            value={status.id}
+          >
+            {status.attributes?.name || 'Unnamed Status'}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        className="btn btn-outline-primary"
+        onClick={() => setShowNewStatus(true)}
+        disabled={loading}
+      >
+        <i className="fas fa-plus"></i> New
+      </button>
+    </div>
+  );
+});
+
+StatusSelect.displayName = 'StatusSelect';
+
+export default StatusSelect;

--- a/frontend/src/components/TransactionForm.js
+++ b/frontend/src/components/TransactionForm.js
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import DatePicker from 'react-datepicker';
 import { createTransaction } from '../services/transactions';
 import { getCategories } from '../services/categories';
+import { getStatuses } from '../services/statuses';
 import CategorySelect from './CategorySelect';
+import StatusSelect from './StatusSelect';
 
 const TransactionForm = ({ onSuccess, onCancel }) => {
   const [formData, setFormData] = useState({
@@ -10,27 +12,35 @@ const TransactionForm = ({ onSuccess, onCancel }) => {
     description: '',
     amount: '',
     category_id: '',
+    status_id: '',
     notes: ''
   });
   const [categories, setCategories] = useState([]);
+  const [statuses, setStatuses] = useState([]);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [categoriesLoading, setCategoriesLoading] = useState(true);
+  const [statusesLoading, setStatusesLoading] = useState(true);
 
-  // Fetch categories when component mounts
+  // Fetch categories and statuses when component mounts
   useEffect(() => {
-    const fetchCategories = async () => {
+    const fetchData = async () => {
       try {
-        const response = await getCategories();
-        setCategories(response?.data || []);
+        const [categoriesResponse, statusesResponse] = await Promise.all([
+          getCategories(),
+          getStatuses()
+        ]);
+        setCategories(categoriesResponse?.data || []);
+        setStatuses(statusesResponse?.data || []);
       } catch (err) {
         setError(err.message);
       } finally {
         setCategoriesLoading(false);
+        setStatusesLoading(false);
       }
     };
 
-    fetchCategories();
+    fetchData();
   }, []);
 
   const handleChange = (e) => {
@@ -140,6 +150,23 @@ const TransactionForm = ({ onSuccess, onCancel }) => {
             />
             {categoriesLoading && (
               <div className="text-muted small mt-1">Loading categories...</div>
+            )}
+          </div>
+
+          <div className="mb-3">
+            <label className="form-label">Status</label>
+            <StatusSelect
+              value={formData.status_id}
+              onChange={(value) => handleChange({ target: { name: 'status_id', value } })}
+              onError={(errorMessage) => setError(errorMessage)}
+              statuses={statuses}
+              onStatusCreated={(newStatus) => {
+                setStatuses(prev => [...prev, newStatus]);
+              }}
+              disabled={statusesLoading}
+            />
+            {statusesLoading && (
+              <div className="text-muted small mt-1">Loading statuses...</div>
             )}
           </div>
 

--- a/frontend/src/components/TransactionForm.js
+++ b/frontend/src/components/TransactionForm.js
@@ -71,7 +71,11 @@ const TransactionForm = ({ onSuccess, onCancel }) => {
       };
 
       await createTransaction(transaction);
-      onSuccess();
+      
+      // Wait for the success callback to complete (in case it does async operations)
+      if (onSuccess) {
+        await onSuccess();
+      }
     } catch (err) {
       setError(err.message);
     } finally {

--- a/frontend/src/components/TransactionList.js
+++ b/frontend/src/components/TransactionList.js
@@ -21,6 +21,7 @@ import {
 import { getCategories } from '../services/categories';
 import TransactionForm from './TransactionForm';
 import BulkCategorySelect from './BulkCategorySelect';
+import BulkStatusSelect from './BulkStatusSelect';
 import CategorySelect from './CategorySelect';
 import { EditableText, EditableNumber } from './EditableFields';
 import { TableSkeleton, FiltersSkeleton, ChartSkeleton } from './LoadingSkeletons';
@@ -64,6 +65,7 @@ const TransactionList = () => {
   
   const [showTransactionForm, setShowTransactionForm] = useState(false);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
+  const [showStatusModal, setShowStatusModal] = useState(false);
   const [selectedRows, setSelectedRows] = useState({});
   const [isProcessing, setIsProcessing] = useState(false);
   const [editingCell, setEditingCell] = useState({ rowId: null, field: null });
@@ -303,17 +305,21 @@ const TransactionList = () => {
     {
       id: 'status',
       header: 'Status',
-      accessorKey: 'attributes.status',
+      accessorKey: 'attributes.status_name',
       cell: info => {
-        const status = info.getValue();
+        const statusName = info.getValue();
         const transaction = info.row.original;
         const anomalyTypes = getAnomalyTypes(transaction);
         
         return (
           <div className="d-flex flex-column align-items-start gap-1">
-            <span className={`badge bg-${status === 'valid' ? 'success' : 'danger'}`}>
-              {status}
-            </span>
+            {statusName ? (
+              <span className={`badge bg-secondary`}>
+                {statusName}
+              </span>
+            ) : (
+              <span className="badge bg-light text-dark">No Status</span>
+            )}
             {anomalyTypes.length > 0 && (
               <div className="d-flex flex-wrap gap-1">
                 {anomalyTypes.map((type, index) => (
@@ -549,7 +555,7 @@ const TransactionList = () => {
     }
   };
 
-  const handleBulkCategoryUpdate = async (categoryId) => {
+    const handleBulkCategoryUpdate = async (categoryId) => {
     try {
       setIsProcessing(true);
       const selectedIds = Object.keys(selectedRows).map(index => data[index].id);
@@ -559,6 +565,31 @@ const TransactionList = () => {
       
       // Close modal and clear selections immediately
       setShowCategoryModal(false);
+      setSelectedRows({});
+      
+      // Refresh data to ensure UI is in sync with backend
+      await Promise.all([
+        fetchTransactions(), 
+        fetchCategoryTotals()
+      ]);
+      
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleBulkStatusSelect = async (statusId) => {
+    try {
+      setIsProcessing(true);
+      const selectedIds = Object.keys(selectedRows).map(index => data[index].id);
+      
+      // Perform bulk status update with status_id
+      await bulkUpdateTransactions(selectedIds, { status_id: statusId });
+      
+      // Close modal and clear selections immediately
+      setShowStatusModal(false);
       setSelectedRows({});
       
       // Refresh data to ensure UI is in sync with backend
@@ -649,6 +680,32 @@ const TransactionList = () => {
         </div>
       )}
 
+      {/* Status Modal */}
+      {showStatusModal && (
+        <div className="modal d-block" tabIndex="-1" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Set Status for Selected Transactions</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setShowStatusModal(false)}
+                  disabled={isProcessing}
+                ></button>
+              </div>
+              <div className="modal-body">
+                <BulkStatusSelect
+                  onSelect={handleBulkStatusSelect}
+                  onCancel={() => setShowStatusModal(false)}
+                  disabled={isProcessing}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Transaction Form Modal */}
       {showTransactionForm && (
         <div className="modal d-block" tabIndex="-1" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
@@ -716,6 +773,14 @@ const TransactionList = () => {
             >
               <i className="fas fa-tag me-1"></i>
               Set Category
+            </button>
+            <button
+              className="btn btn-secondary btn-sm me-2"
+              onClick={() => setShowStatusModal(true)}
+              disabled={isProcessing}
+            >
+              <i className="fas fa-flag me-1"></i>
+              Set Status
             </button>
             <button
               className="btn btn-danger btn-sm"

--- a/frontend/src/components/TransactionList.js
+++ b/frontend/src/components/TransactionList.js
@@ -115,10 +115,10 @@ const TransactionList = () => {
   };
 
   // Optimized data fetching functions
-  const fetchTransactions = useCallback(async (showLoading = true) => {
+  const fetchTransactions = useCallback(async (showLoading = true, bustCache = false) => {
     try {
       if (showLoading) setTransactionsLoading(true);
-      const response = await getTransactions(filters);
+      const response = await getTransactions(filters, bustCache);
       setData(response.data || []);
       setPagination({
         currentPage: response.meta?.current_page || 1,
@@ -545,7 +545,7 @@ const TransactionList = () => {
       
       // Refresh data to ensure UI is in sync with backend
       await Promise.all([
-        fetchTransactions(), 
+        fetchTransactions(false, true), // Use cache busting
         fetchCategoryTotals()
       ]);
       
@@ -573,7 +573,7 @@ const TransactionList = () => {
       
       // Refresh data to ensure UI is in sync with backend
       await Promise.all([
-        fetchTransactions(), 
+        fetchTransactions(false, true), // Use cache busting
         fetchCategoryTotals()
       ]);
       
@@ -597,7 +597,7 @@ const TransactionList = () => {
       
       // Refresh data to ensure UI is in sync with backend
       await Promise.all([
-        fetchTransactions(), 
+        fetchTransactions(false, true), // Use cache busting
         fetchCategoryTotals()
       ]);
       
@@ -622,7 +622,7 @@ const TransactionList = () => {
       
       // Refresh data to ensure UI is in sync with backend
       await Promise.all([
-        fetchTransactions(), 
+        fetchTransactions(false, true), // Use cache busting
         fetchCategoryTotals()
       ]);
       
@@ -647,7 +647,7 @@ const TransactionList = () => {
       
       // Refresh data to ensure UI is in sync with backend
       await Promise.all([
-        fetchTransactions(), 
+        fetchTransactions(false, true), // Use cache busting
         fetchCategoryTotals()
       ]);
       
@@ -764,12 +764,19 @@ const TransactionList = () => {
         <div className="modal d-block" tabIndex="-1" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
           <div className="modal-dialog">
             <TransactionForm
-              onSuccess={() => {
+              onSuccess={async () => {
+                // Close modal first to provide immediate feedback
                 setShowTransactionForm(false);
-                fetchTransactions();
-                fetchCategories();
-                fetchStatuses();
-                fetchCategoryTotals(); // Refresh category totals for pie chart
+                
+                // Force immediate refresh of transactions with cache busting
+                await fetchTransactions(false, true);
+                
+                // Then refresh other data in parallel
+                await Promise.all([
+                  fetchCategories(),
+                  fetchStatuses(),
+                  fetchCategoryTotals()
+                ]);
               }}
               onCancel={() => setShowTransactionForm(false)}
             />

--- a/frontend/src/components/TransactionList.js
+++ b/frontend/src/components/TransactionList.js
@@ -19,6 +19,7 @@ import {
   updateTransaction
 } from '../services/transactions';
 import { getCategories } from '../services/categories';
+import { getStatuses } from '../services/statuses';
 import TransactionForm from './TransactionForm';
 import BulkCategorySelect from './BulkCategorySelect';
 import BulkStatusSelect from './BulkStatusSelect';
@@ -34,6 +35,7 @@ const TransactionList = () => {
   // Separate loading states for progressive loading
   const [transactionsLoading, setTransactionsLoading] = useState(true);
   const [categoriesLoading, setCategoriesLoading] = useState(true);
+  const [statusesLoading, setStatusesLoading] = useState(true);
   const [categoryTotalsLoading, setCategoryTotalsLoading] = useState(true);
   
   // Data states
@@ -41,6 +43,7 @@ const TransactionList = () => {
   const [sorting, setSorting] = useState([]);
   const [categoryTotals, setCategoryTotals] = useState([]);
   const [categories, setCategories] = useState([]);
+  const [statuses, setStatuses] = useState([]);
   const [error, setError] = useState(null);
   
   // Get URL search params
@@ -49,6 +52,7 @@ const TransactionList = () => {
     startDate: null,
     endDate: null,
     status: searchParams.get('status') || '',
+    status_id: searchParams.get('status_id') || '',
     search: searchParams.get('search') || '',
     category: searchParams.has('category') ? searchParams.get('category') : undefined,
     page: parseInt(searchParams.get('page')) || 1,
@@ -142,6 +146,17 @@ const TransactionList = () => {
     }
   }, []);
 
+  const fetchStatuses = useCallback(async () => {
+    try {
+      const response = await getStatuses();
+      setStatuses(response.data || []);
+      setStatusesLoading(false);
+    } catch (err) {
+      console.error('Statuses fetch error:', err);
+      setStatusesLoading(false);
+    }
+  }, []);
+
   const fetchCategoryTotals = useCallback(async () => {
     try {
       const response = await getCategoryTotals();
@@ -162,8 +177,9 @@ const TransactionList = () => {
     // Start all requests in parallel
     fetchTransactions();
     fetchCategories();
+    fetchStatuses();
     fetchCategoryTotals();
-  }, [fetchTransactions, fetchCategories, fetchCategoryTotals]);
+  }, [fetchTransactions, fetchCategories, fetchStatuses, fetchCategoryTotals]);
 
   // Function to clear all filters and refresh data
   const clearAllFilters = useCallback(async () => {
@@ -171,6 +187,7 @@ const TransactionList = () => {
       startDate: null,
       endDate: null,
       status: '',
+      status_id: '',
       search: '',
       category: undefined,
       page: 1,
@@ -307,19 +324,42 @@ const TransactionList = () => {
       header: 'Status',
       accessorKey: 'attributes.status_name',
       cell: info => {
-        const statusName = info.getValue();
+        const customStatusName = info.getValue();
         const transaction = info.row.original;
+        const systemStatus = transaction.attributes?.status;
         const anomalyTypes = getAnomalyTypes(transaction);
+        
+        // Helper function to get system status badge styling
+        const getSystemStatusBadge = (status) => {
+          switch (status) {
+            case 'valid':
+              return { class: 'bg-success', text: 'Valid' };
+            case 'invalid':
+              return { class: 'bg-danger', text: 'Invalid' };
+            case 'custom':
+              return { class: 'bg-info', text: 'Custom' };
+            default:
+              return { class: 'bg-secondary', text: status || 'Unknown' };
+          }
+        };
+        
+        const systemBadge = getSystemStatusBadge(systemStatus);
         
         return (
           <div className="d-flex flex-column align-items-start gap-1">
-            {statusName ? (
-              <span className={`badge bg-secondary`}>
-                {statusName}
+            {/* System Status - Always displayed */}
+            <span className={`badge ${systemBadge.class}`}>
+              {systemBadge.text}
+            </span>
+            
+            {/* Custom Status - Show when present */}
+            {customStatusName && (
+              <span className="badge bg-secondary">
+                {customStatusName}
               </span>
-            ) : (
-              <span className="badge bg-light text-dark">No Status</span>
             )}
+            
+            {/* Anomaly badges */}
             {anomalyTypes.length > 0 && (
               <div className="d-flex flex-wrap gap-1">
                 {anomalyTypes.map((type, index) => (
@@ -424,21 +464,34 @@ const TransactionList = () => {
         ...newFilters,
         has_anomalies: true,
         exclude_anomalies: false,
-        status: ''
+        status: '',
+        status_id: ''
       };
     } else if (value === 'flagged_only') {
       newFilters = {
         ...newFilters,
         exclude_anomalies: true,
         has_anomalies: false,
-        status: 'invalid'
+        status: 'invalid',
+        status_id: ''
+      };
+    } else if (value.startsWith('status_')) {
+      // Custom status filter
+      const statusId = value.replace('status_', '');
+      newFilters = {
+        ...newFilters,
+        has_anomalies: false,
+        exclude_anomalies: false,
+        status: value, // Keep the full value for UI state only
+        status_id: statusId // Send the ID to backend
       };
     } else {
       newFilters = {
         ...newFilters,
         has_anomalies: false,
         exclude_anomalies: false,
-        status: value
+        status: value,
+        status_id: '' // Clear status_id when using system status
       };
     }
     
@@ -715,6 +768,7 @@ const TransactionList = () => {
                 setShowTransactionForm(false);
                 fetchTransactions();
                 fetchCategories();
+                fetchStatuses();
                 fetchCategoryTotals(); // Refresh category totals for pie chart
               }}
               onCancel={() => setShowTransactionForm(false)}
@@ -795,7 +849,7 @@ const TransactionList = () => {
       )}
 
       {/* Filters */}
-      {categoriesLoading ? (
+      {(categoriesLoading || statusesLoading) ? (
         <FiltersSkeleton />
       ) : (
         <div className="card mb-4">
@@ -803,7 +857,7 @@ const TransactionList = () => {
             <div className="row g-3">
               <div className="d-flex justify-content-between align-items-center mb-3">
                 <h6 className="mb-0">Filters</h6>
-                {(filters.startDate || filters.endDate || filters.status || filters.search || filters.category || filters.exclude_anomalies || filters.has_anomalies) && (
+                {(filters.startDate || filters.endDate || filters.status || filters.status_id || filters.search || filters.category || filters.exclude_anomalies || filters.has_anomalies) && (
                   <button
                     className="btn btn-outline-secondary btn-sm"
                     onClick={clearAllFilters}
@@ -843,11 +897,25 @@ const TransactionList = () => {
                   onChange={e => handleStatusFilterChange(e.target.value)}
                 >
                   <option value="">All</option>
-                  <option value="valid">Valid</option>
-                  <option value="invalid">Invalid (All)</option>
-                  <option value="flagged_only">Flagged (Manual/Rules)</option>
-                  <option value="anomalies">Anomalies (System Detected)</option>
-                  <option value="high_value">High Value</option>
+                  <optgroup label="System Status">
+                    <option value="valid">Valid</option>
+                    <option value="invalid">Invalid (All)</option>
+                    <option value="flagged_only">Flagged (Manual/Rules)</option>
+                    <option value="anomalies">Anomalies (System Detected)</option>
+                    <option value="high_value">High Value</option>
+                  </optgroup>
+                  {statuses.length > 0 && (
+                    <optgroup label="Custom Status">
+                      {statuses.map(status => (
+                        <option 
+                          key={`status_${status.id}`} 
+                          value={`status_${status.id}`}
+                        >
+                          {status.attributes?.name || 'Unnamed Status'}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
                 </select>
               </div>
               <div className="col-md-3">

--- a/frontend/src/services/statuses.js
+++ b/frontend/src/services/statuses.js
@@ -1,0 +1,34 @@
+import api from './api';
+
+export const getStatuses = async () => {
+  try {
+    const response = await api.get('/statuses');
+    console.log('Statuses API response:', response); // Debug log
+    return response.data;
+  } catch (error) {
+    console.error('Statuses API error:', error.response); // Debug log
+    throw new Error(error.response?.data?.message || 'Failed to fetch statuses');
+  }
+};
+
+export const createStatus = async (data) => {
+  try {
+    const response = await api.post('/statuses', { status: data });
+    console.log('Create status response:', response); // Debug log
+    return response.data;
+  } catch (error) {
+    console.error('Create status error:', error.response); // Debug log
+    throw new Error(error.response?.data?.message || 'Failed to create status');
+  }
+};
+
+export const deleteStatus = async (id) => {
+  try {
+    const response = await api.delete(`/statuses/${id}`);
+    console.log('Delete status response:', response); // Debug log
+    return response.data;
+  } catch (error) {
+    console.error('Delete status error:', error.response); // Debug log
+    throw new Error(error.response?.data?.message || 'Failed to delete status');
+  }
+};

--- a/frontend/src/services/transactions.js
+++ b/frontend/src/services/transactions.js
@@ -1,9 +1,14 @@
 import api from './api';
 
-export const getTransactions = async (filters = {}) => {
+export const getTransactions = async (filters = {}, bustCache = false) => {
   try {
     // Transform camelCase to snake_case for backend compatibility
     const transformedParams = { ...filters };
+    
+    // Add cache busting parameter if requested
+    if (bustCache) {
+      transformedParams._bust = Date.now();
+    }
     
     // Handle custom status filtering - only send status_id if it's a custom status
     if (transformedParams.status && transformedParams.status.startsWith('status_')) {

--- a/frontend/src/services/transactions.js
+++ b/frontend/src/services/transactions.js
@@ -5,6 +5,19 @@ export const getTransactions = async (filters = {}) => {
     // Transform camelCase to snake_case for backend compatibility
     const transformedParams = { ...filters };
     
+    // Handle custom status filtering - only send status_id if it's a custom status
+    if (transformedParams.status && transformedParams.status.startsWith('status_')) {
+      // For custom statuses, only send status_id, not the prefixed status
+      console.log('Custom status filter detected:', transformedParams.status, 'sending status_id:', transformedParams.status_id);
+      delete transformedParams.status;
+    } else if (transformedParams.status_id) {
+      // If we have status_id but status doesn't start with 'status_', clear status_id
+      console.log('System status filter detected:', transformedParams.status, 'clearing status_id');
+      delete transformedParams.status_id;
+    }
+    
+    console.log('Final transaction filter params:', transformedParams);
+    
     // Handle parameter name transformations
     if (transformedParams.perPage) {
       transformedParams.per_page = transformedParams.perPage;


### PR DESCRIPTION
Adding a feature for manual user statuses that allows users to define a custom status and assign it to a transaction.

These user statuses work alongside the already implement system statuses for valid/invalid transaction marking.

The user can select or create a new user status from the new transaction form, the inline transaction editor, as well as in the rule creation form.

User can filter transactions based on system status as well as newly implement user statuses.

System status are always visible in the transactions list.

Custom user status are only visible if they are assigned to the transaction.

<img width="1053" height="504" alt="Screenshot 2025-08-27 at 5 29 05 PM" src="https://github.com/user-attachments/assets/d077d0f4-9096-4f00-84ac-2ee5c5649f13" />

---

I also went ahead and took the liberty to address the caching issue we saw during our demonstration today.